### PR TITLE
Fix capitalization in README.md first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The simplest way to use Logrus is simply the package-level exported logger:
 package main
 
 import (
-  log "github.com/Sirupsen/logrus"
+  log "github.com/sirupsen/logrus"
 )
 
 func main() {


### PR DESCRIPTION
sorry to bring up potentially old wounds - the example import should seemingly be lower-case.